### PR TITLE
Fixed white dialogs

### DIFF
--- a/src/gui/instancewidget.py
+++ b/src/gui/instancewidget.py
@@ -98,6 +98,7 @@ class InstanceWidget(QWidget):
         prog = QProgressDialog('Fetching Connections...', 'Hide', 0, 0, parent=self.window())
         prog.setModal(True)
         prog.setWindowTitle('Fetching Connections...')
+        prog.show()
 
         def populate(connections):
             self.ui.allConnectionsList.clear()
@@ -136,6 +137,7 @@ class InstanceWidget(QWidget):
         prog = QProgressDialog(msg, 'Hide', 0, 0, parent=self.window())
         prog.setModal(True)
         prog.setWindowTitle(msg)
+        prog.show()
 
         def populate(templates):
             self.numTemplates = 0
@@ -282,6 +284,7 @@ class InstanceWidget(QWidget):
             prog = QProgressDialog('Deleting Template...', 'Hide', 0, 0, parent=self.window())
             prog.setModal(True)
             prog.setWindowTitle('Deleting...')
+            prog.show()
 
             task = Task(deleteTemplate)
             task.finished.connect(prog.close)
@@ -321,6 +324,7 @@ class InstanceWidget(QWidget):
                 prog = QProgressDialog('Saving Template...', 'Hide', 0, 0, parent=self.window())
                 prog.setModal(True)
                 prog.setWindowTitle('Saving...')
+                prog.show()
 
                 task = Task(session.commit)
                 task.finished.connect(prog.close)
@@ -450,6 +454,7 @@ class InstanceWidget(QWidget):
         prog = QProgressDialog('Processing Collected Data...', 'Hide', 0, 0, parent=self.window())
         prog.setModal(True)
         prog.setWindowTitle("Processing...")
+        prog.show()
 
         task = Task(lambda: processScrapedConnections(conns, self.account))
         task.finished.connect(prog.close)

--- a/src/gui/newclientdialog.py
+++ b/src/gui/newclientdialog.py
@@ -71,6 +71,7 @@ class NewClientDialog(QDialog):
 
         prog = QProgressDialog("Creating new client. please wait...", "Hide", 0, 0, parent=self)
         prog.setModal(True)
+        prog.show()
 
         def addToDB():
             session.add_all(dbEntries)

--- a/src/gui/newinstancedialog.py
+++ b/src/gui/newinstancedialog.py
@@ -46,6 +46,7 @@ class NewInstanceDialog(QDialog):
         """Fetches all clients from the database and populates the client combo box with them"""
         prog = QProgressDialog("Fetching clients, please wait...", "Hide", 0, 0, parent=self)
         prog.setModal(True)
+        prog.show()
 
         def populate(clients):
             for client in clients:


### PR DESCRIPTION
@Frenchman98 I corrected you too soon on the use of show() vs. exec_() on the progress bars. I just realized that I was getting a lot of white dialogs after I made my change to only use exec_(). I fixed the issue by calling show() right when we create the progress dialog, then after the task is started, I call exec_() to block until the progress dialog is closed.