### PR TITLE
preview uses most up-to-date template

### DIFF
--- a/src/gui/instancewidget.py
+++ b/src/gui/instancewidget.py
@@ -220,6 +220,10 @@ class InstanceWidget(QWidget):
 
         if start:
             self.saveCurrentTemplate()
+
+            # NOTE: Since another thread saves different objects to the database, committing forces
+            #       us to go back to the database and get the freshest version of an object
+            Session.commit()
             template = self.ui.templatesBox.currentData()
 
             if fromHTML(template.message_template) != template.message_template:


### PR DESCRIPTION
Prior to this PR, the preview dialog wasn't showing the most up-to-date message from the GUI. This is because another thread (and therefore another session) saved the template, so the template objects were outdated.

Now that we're using multiple sessions, it's possible that some objects from other sessions may be sort of "outdated". To fix this, we can just commit the session which invalidates all the objects in that session and makes us pull from the database again instead of using the outdated objects.