### PR TITLE
Added fallback method for opening messaging popup

### DIFF
--- a/src/common/strings.py
+++ b/src/common/strings.py
@@ -17,6 +17,9 @@ def equalTo(s1, s2, normalize_whitespace=True, normalize_html_chars=True):
 
     return s1 == s2
 
+def xpathConcat(s, quotation="'"):
+    return f"concat({quotation}" + f"{quotation}, {quotation}".join(list(s)) + f"{quotation})"
+
 
 def fromHTML(astring):
     return html.unescape(astring)

--- a/src/gui/instancewidget.py
+++ b/src/gui/instancewidget.py
@@ -321,8 +321,11 @@ class InstanceWidget(QWidget):
                 startStopButton.setChecked(False)
                 return
 
-            # Getting query items from selected list
-            connections = [self.allConnections[name] for name in self.selectedConnections]
+            # Only get connections that haven't already been sent this message.
+            already_sent = [message.recipient_connection_id for message in Session.query(LinkedInMessage).filter(LinkedInMessage.template_id == template.id)]
+            connections = Session.query(LinkedInConnection)\
+                .filter(LinkedInConnection.account_id == self.account.id)\
+                .filter(LinkedInConnection.id.notin_(already_sent))
 
             # Show a preview of the message and ask if the operator would like to proceed
             preview = MessagePreviewDialog(self, connections, template)

--- a/src/gui/ui/instancewidget.ui
+++ b/src/gui/ui/instancewidget.ui
@@ -38,7 +38,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>1</number>
+      <number>3</number>
      </property>
      <property name="iconSize">
       <size>
@@ -731,7 +731,7 @@
          <item>
           <widget class="QGroupBox" name="groupBox">
            <property name="title">
-            <string>Messaging Speed Controls</string>
+            <string>Message Throttling</string>
            </property>
            <layout class="QFormLayout" name="formLayout">
             <item row="0" column="0">


### PR DESCRIPTION
There was a weird situation where Linkedin wouldn't load any connections when we would search for them. If we've exhausted all attempts in the finding the connection in the messaging popup, we fall back to the "my network" page to do the search.

I also only try sending the message to connections that haven't already been sent the same template.